### PR TITLE
Fix transport options creation

### DIFF
--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -312,7 +312,18 @@ export function useConnection({
           mcpProxyServerUrl.searchParams.append("command", command);
           mcpProxyServerUrl.searchParams.append("args", args);
           mcpProxyServerUrl.searchParams.append("env", JSON.stringify(env));
-          transportOptions = {};
+          transportOptions = {
+            authProvider: serverAuthProvider,
+            eventSourceInit: {
+              fetch: (
+                url: string | URL | globalThis.Request,
+                init: RequestInit | undefined,
+              ) => fetch(url, { ...init, headers }),
+            },
+            requestInit: {
+              headers,
+            },
+          };
           break;
 
         case "sse":


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Create the appropriate TransportOptions object for the selected transport
* In useConnection.ts
  - import `SSEClientTransportOptions` and `StreamableHTTPClientTransportOptions`
  - refactor/move the `switch` on `transportType` that only created the `mcpProxyServerURL` down into the `try` block where the transport options are set.
  - In the case for **"stdio"**
    - let the `transportOptions` be appropriate for `sse`  because it will use SSE transport to the proxy in this case
  - In the case for **"sse"**
    - create `transportOptions` appropriate for `sse` (same as what was being created before, except adding `authProvider: serverAuthProvider`
  - In the case for **"streamableHttp"**
    - create `transportOptions`appropriate for `streamableHttp` (similar to `sse`, only adding `reconnectionOptions` and `authProvider: serverAuthProvider`)
  
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
* Amending the changes for [this PR](https://github.com/modelcontextprotocol/inspector/pull/370)
* Create the appropriate `transportOptions` for the selected transport.
* Also include `authProvider: serverAuthProvider` for both SSE and StreamableHttp

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
